### PR TITLE
Fixed: Lift from not allowing to activate when true

### DIFF
--- a/Assets/Scripts/ObjectScripts/Lift.cs
+++ b/Assets/Scripts/ObjectScripts/Lift.cs
@@ -81,13 +81,13 @@ public class Lift : WorldObject {
     public override void Lock()
     {
         isLocked = true;
-        activate = false;
     }
     /* Note: if you unlokcing a lift and want to activate 
      * right now, then set the activate bool to true as well*/
     public override void Unlock()
     {
         isLocked = false;
+        isOpen = true;
     }
 
     public override void OpenMove()


### PR DESCRIPTION
Lift now activates when bool is set to true and is unlocked